### PR TITLE
Point to international addon page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WIP
 - Linux: [deb](https://github.com/Flam3rboy/discord-bot-client/releases/download/3.0.0/discord-bot-client_3.0.0_amd64.deb)
 
 ### Extension
-- [Firefox](https://addons.mozilla.org/de/firefox/addon/discord-bot-client/)
+- [Firefox](https://addons.mozilla.org/firefox/addon/discord-bot-client/)
 - Chrome (coming soon)
 - [Other (.zip)](https://github.com/Flam3rboy/discord-bot-client/releases/download/3.0.0/extension.zip)
 


### PR DESCRIPTION
**Points to addon page without any country specified and lets Firefox Addons decide the country instead of showing the German page.**
The current URL for the Firefox addon goes to the German page of the addon. This small change removes all indication of the locale so that Firefox Addons can choose the right language. This is just a small change but one that can make it easier for everyone to read info about the addon.